### PR TITLE
Improve language switch transition

### DIFF
--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Layout from "@/components/Layout";
+import { LangProvider } from "@/context/LangContext";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -19,7 +20,9 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body className="antialiased bg-background text-foreground">
-        <Layout>{children}</Layout>
+        <LangProvider>
+          <Layout>{children}</Layout>
+        </LangProvider>
       </body>
     </html>
   );

--- a/my-app/src/app/page.tsx
+++ b/my-app/src/app/page.tsx
@@ -101,7 +101,7 @@ export default function HomePage() {
       );
       setSent(true);
       form.reset();
-    } catch (err) {
+    } catch {
       setError('Erro ao enviar. Tente novamente.');
     } finally {
       setSending(false);

--- a/my-app/src/components/Header.tsx
+++ b/my-app/src/components/Header.tsx
@@ -9,7 +9,7 @@ import { text } from '../lib/text';
 export default function Header() {
   const [open, setOpen] = useState(false);
   const [dark, setDark] = useState(false);
-  const { lang, setLang, isLangTransitioning, triggerLangTransition } = useLang();
+  const { lang, setLang, triggerLangTransition } = useLang();
 
   useEffect(() => {
     const stored = localStorage.getItem('theme');

--- a/my-app/src/components/Header.tsx
+++ b/my-app/src/components/Header.tsx
@@ -66,7 +66,8 @@ export default function Header() {
           <button
             onClick={() => {
               triggerLangTransition();
-              setTimeout(() => setLang(lang === 'en' ? 'pt' : 'en'), 200);
+              // Change the language when the animation is halfway through
+              setTimeout(() => setLang(lang === 'en' ? 'pt' : 'en'), 300);
             }}
             aria-label="Toggle language"
             className="p-2 rounded hover:bg-surface text-xs font-semibold"

--- a/my-app/src/components/Layout.tsx
+++ b/my-app/src/components/Layout.tsx
@@ -1,13 +1,12 @@
 'use client';
 import { AnimatePresence, motion } from 'framer-motion';
-import { LangProvider, useLang } from '../context/LangContext';
+import { useLang } from '../context/LangContext';
 import Footer from './Footer';
 import Header from './Header';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { isLangTransitioning } = useLang();
   return (
-    <LangProvider>
       <div className="flex flex-col min-h-screen relative" id="home">
         <Header />
         <main className="flex-1 pt-16">
@@ -18,12 +17,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                transition={{ duration: 0.5 }}
-                className="fixed inset-0 z-50"
-                style={{
-                  background: 'linear-gradient(90deg, var(--background), var(--foreground))',
-                  mixBlendMode: 'screen',
-                }}
+                transition={{ duration: 0.4 }}
+                className="fixed inset-0 z-50 bg-foreground"
+                style={{ mixBlendMode: 'difference' }}
               />
             )}
           </AnimatePresence>
@@ -33,6 +29,5 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         </main>
         <Footer />
       </div>
-    </LangProvider>
   );
 }

--- a/my-app/src/components/Layout.tsx
+++ b/my-app/src/components/Layout.tsx
@@ -14,12 +14,15 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             {isLangTransitioning && (
               <motion.div
                 key="lang-transition"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.4 }}
-                className="fixed inset-0 z-50 bg-foreground"
-                style={{ mixBlendMode: 'difference' }}
+                initial={{ y: '-100%' }}
+                animate={{ y: 0 }}
+                exit={{ y: '100%' }}
+                transition={{ duration: 0.6, ease: 'easeInOut' }}
+                className="fixed inset-0 z-50 pointer-events-none"
+                style={{
+                  background:
+                    'linear-gradient(120deg, var(--color2), var(--color3))',
+                }}
               />
             )}
           </AnimatePresence>

--- a/my-app/src/context/LangContext.tsx
+++ b/my-app/src/context/LangContext.tsx
@@ -35,7 +35,8 @@ export function LangProvider({ children }: { children: React.ReactNode }) {
 
   const triggerLangTransition = () => {
     setIsLangTransitioning(true);
-    setTimeout(() => setIsLangTransitioning(false), 400);
+    // Allow a slightly longer transition for a clearer effect
+    setTimeout(() => setIsLangTransitioning(false), 600);
   };
 
   return (


### PR DESCRIPTION
## Summary
- wrap layout with `LangProvider` in root layout
- simplify language context usage in `Layout`
- make the language change overlay more visible
- clean up unused variables and fix an unused catch parameter

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865874fb108832784183f023143bb08