### PR TITLE
Simplify transitions

### DIFF
--- a/my-app/src/app/page.tsx
+++ b/my-app/src/app/page.tsx
@@ -117,7 +117,7 @@ export default function HomePage() {
         <motion.div
           initial={{ y: -20, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.8 }}
+          transition={{ duration: 0.5 }}
           className="text-center md:text-left"
         >
           <h1 className="text-4xl font-bold mb-4 relative">
@@ -154,7 +154,7 @@ export default function HomePage() {
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 1, duration: 0.8 }}
+          transition={{ delay: 0.3, duration: 0.5 }}
         >
           <Image
             src="/profile.jpg"
@@ -217,11 +217,10 @@ export default function HomePage() {
           {projects.map((p) => (
             <motion.div
               key={p.title}
-              whileHover={{ scale: 1.05, boxShadow: '0px 10px 30px rgba(0,0,0,0.1)' }}
               initial={{ opacity: 0, y: 50 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              className="bg-surface p-4 rounded shadow flex flex-col border border-border"
+              className="bg-surface p-4 rounded shadow flex flex-col border border-border transform transition-transform hover:scale-105 hover:shadow-lg"
             >
               <Image
                 src={p.img}

--- a/my-app/src/components/Footer.tsx
+++ b/my-app/src/components/Footer.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { motion } from 'framer-motion';
 import { FaGithub, FaInstagram } from 'react-icons/fa';
 
 export default function Footer() {
@@ -12,15 +11,14 @@ export default function Footer() {
       <div className="max-w-5xl mx-auto flex flex-col items-center gap-2">
         <div className="flex gap-4">
           {socials.map((s) => (
-            <motion.a
+            <a
               key={s.href}
-              whileHover={{ scale: 1.1 }}
               href={s.href}
-              className="text-primary"
+              className="text-primary transition-transform hover:scale-110"
             >
               <s.icon className="w-5 h-5" />
               <span className="sr-only">{s.label}</span>
-            </motion.a>
+            </a>
           ))}
         </div>
         <p className="text-xs text-foreground">&copy; {new Date().getFullYear()} João Vitor Fernandes Manfrim</p>

--- a/my-app/src/components/Header.tsx
+++ b/my-app/src/components/Header.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { AnimatePresence, motion } from 'framer-motion';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { FaMoon, FaSun } from 'react-icons/fa';
@@ -93,27 +92,22 @@ export default function Header() {
           </button>
         </div>
       </div>
-      <AnimatePresence>
-        {open && (
-          <motion.nav
-            initial={{ height: 0 }}
-            animate={{ height: 'auto' }}
-            exit={{ height: 0 }}
-            className="md:hidden bg-header border-t border-border"
-          >
-            {links.map((l) => (
-              <a
-                key={l.href}
-                href={l.href}
-                onClick={handleNavClick(l.href)}
-                className="block px-4 py-2 hover:bg-surface"
-              >
-                {text[lang][l.key]}
-              </a>
-            ))}
-          </motion.nav>
-        )}
-      </AnimatePresence>
+      <nav
+        className="md:hidden bg-header border-t border-border overflow-hidden transition-[max-height] duration-300"
+        style={{ maxHeight: open ? '200px' : '0px' }}
+      >
+        {open &&
+          links.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              onClick={handleNavClick(l.href)}
+              className="block px-4 py-2 hover:bg-surface"
+            >
+              {text[lang][l.key]}
+            </a>
+          ))}
+      </nav>
     </header>
   );
 }

--- a/my-app/src/components/Layout.tsx
+++ b/my-app/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { AnimatePresence, motion } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { useLang } from '../context/LangContext';
 import Footer from './Footer';
 import Header from './Header';
@@ -7,36 +7,19 @@ import Header from './Header';
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { isLangTransitioning } = useLang();
   return (
-      <div
-        className="flex flex-col min-h-screen relative transition-[filter] duration-500"
-        id="home"
-        style={{ filter: isLangTransitioning ? 'url(#ripple-effect) blur(20px)' : 'none' }}
-      >
-        {isLangTransitioning && (
-          <svg className="absolute w-0 h-0">
-            <filter id="ripple-effect">
-              <feTurbulence type="fractalNoise" baseFrequency="0.01" numOctaves="1" result="T" />
-              <feDisplacementMap in="SourceGraphic" in2="T" scale="0">
-                <animate attributeName="scale" values="100;400;100" dur="0.6s" />
-              </feDisplacementMap>
-            </filter>
-          </svg>
-        )}
+      <div className="flex flex-col min-h-screen relative" id="home">
         <Header />
         <main className="flex-1 pt-16">
-          <AnimatePresence>
-            {isLangTransitioning && (
-              <motion.div
-                key="lang-transition"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.6, ease: 'easeInOut' }}
-                className="fixed inset-0 z-50 pointer-events-none bg-background/40 backdrop-blur-sm"
-              />
-            )}
-          </AnimatePresence>
-          <div className={isLangTransitioning ? 'pointer-events-none select-none' : ''}>
+          {isLangTransitioning && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className="fixed inset-0 z-50 pointer-events-none bg-background/50"
+            />
+          )}
+          <div className={isLangTransitioning ? 'pointer-events-none select-none blur-sm transition-all duration-300' : 'transition-all duration-300'}>
             {children}
           </div>
         </main>


### PR DESCRIPTION
## Summary
- lighten layout overlay effect
- drop framer animations from header and footer
- reduce animation durations on the homepage

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866f80d21b48327899914dc5f4e7dd4